### PR TITLE
Adds gmail test plugin using an application password

### DIFF
--- a/Plugins/com.gmail/plugin-config.json
+++ b/Plugins/com.gmail/plugin-config.json
@@ -1,0 +1,6 @@
+{
+	"id": "com.gmail",
+	"display_name": "Gmail",
+	"needsVerification": true,
+	"check_interval": 300
+}

--- a/Plugins/com.gmail/plugin.js
+++ b/Plugins/com.gmail/plugin.js
@@ -1,0 +1,58 @@
+const feedUrl = "https://mail.google.com/mail/feed/atom";
+
+function identify() {
+  if (appPassword == null || appPassword.length <= 0) {
+    return setIdentifier(null);
+  }
+
+  const authHeader = {"Authorization": `Basic ${appPassword}`};
+  sendRequest(feedUrl, null, null, authHeader)
+    .then((xmlResponse, others) => {
+      const jsonObject = xmlParse(xmlResponse);
+      const feedTitle = jsonObject.feed.title
+      const accountEmail = feedTitle.split(" ").pop()
+      setIdentifier(accountEmail);
+    })
+    .catch((requestError) => {
+      setIdentifier(null);
+    });
+}
+
+function load() {
+  const authHeader = {"Authorization": `Basic ${appPassword}`};
+  sendRequest(feedUrl, null, null,authHeader)
+    .then((xmlResponse) => {
+      const jsonObject = xmlParse(xmlResponse);
+      if (jsonObject.feed != null) {
+        const feedName = jsonObject.feed.title;
+        const linkAttrs = jsonObject.feed.link$attrs;
+        const feedUrl = linkAttrs.href;
+        const baseUrl = feedUrl.split("/").splice(0,3).join("/");
+        const feedAvatar = baseUrl + "/favicon.ico";
+        const entries = jsonObject.feed.entry;
+        let posts = entries.map(toPosts(feedUrl, feedAvatar));
+        processResults(posts);
+      }
+      else {
+        processResults([]);
+      }
+    })
+    .catch((requestError) => {
+      processError(requestError);
+    });
+}
+
+function toPosts(feedUrl, feedAvatar) {
+  return (feedEntry) => {
+    const entryLinkAttributes = feedEntry.link$attrs;
+    const authorName = feedEntry.author.name;
+    let entryUrl = entryLinkAttributes.href;
+    let date = new Date(feedEntry.issued);
+    const content = feedEntry.title;
+    const post = Post.createWithUriDateContent(entryUrl, date, content);
+    const creator = Creator.createWithUriName(feedUrl, authorName);
+    creator.avatar = feedAvatar;
+    post.creator = creator;
+    return post;
+  }
+}

--- a/Plugins/com.gmail/ui-config.json
+++ b/Plugins/com.gmail/ui-config.json
@@ -1,0 +1,11 @@
+{
+	"inputs": [
+		{
+			"name": "appPassword",
+			"type": "string",
+			"prompt": "appPassword",
+			"validate_as": "string",
+			"placeholder": "base64 encoded <email:password>"
+		},
+	]
+}


### PR DESCRIPTION
To be able to use this plugin you need to create a gmail Application password ([here](https://myaccount.google.com/apppasswords))

## How to create the appPassword
In order to authenticate with gmail we will need to base64 encode our email and password. The result will be the string that we should configure this plugin with (`appPassword`).

open your terminal and run the command:
`echo -n <email>:<appPassword> | base64`

### Example
For example lets say my `email` were "test@gmail.com" and my `appPassword` were "test app password". The command being run in the terminal should look like this:

`echo -n test@gmail.com:"test app password" | base64`