### PR TITLE
Mastodon: Add support for filtering by author

### DIFF
--- a/Plugins/org.joinmastodon/plugin.js
+++ b/Plugins/org.joinmastodon/plugin.js
@@ -188,7 +188,7 @@ function postForItem(item, date = null, shortcodes = {}) {
 	return post;
 }
 
-function queryHomeTimeline(endDate) {
+function queryHomeTimeline(endDate, authors) {
 
 	// NOTE: These constants are related to the feed limits within Tapestry - it doesn't store more than
 	// 3,000 items or things older than 30 days.
@@ -273,8 +273,11 @@ function queryHomeTimeline(endDate) {
 						post.annotations = [annotation];
 					}
 						
-					results.push(post);
-		
+					let author = item["account"]["acct"];
+					if (authors.length === 0 || authors.includes(author)) {
+						results.push(post);
+					}
+
 					lastId = item["id"];
 					lastDate = date;
 				}
@@ -449,7 +452,7 @@ function load() {
 	if (includeHome == "on") {
 		let startTimestamp = (new Date()).getTime();
 
-		queryHomeTimeline(endDate)
+		queryHomeTimeline(endDate, filterByAuthors.split(",").map((author) => author.trim()))
   		.then((parameters) =>  {
   			results = parameters[0];
   			newestItemDate = parameters[1];

--- a/Plugins/org.joinmastodon/ui-config.json
+++ b/Plugins/org.joinmastodon/ui-config.json
@@ -17,5 +17,11 @@
 			"type": "switch",
 			"prompt": "Include Mentions From Others"
 		},
+		{
+			"name": "filterByAuthors",
+			"type": "text",
+			"placeholder": "@a@example.com, @b@example.com",
+			"prompt": "Include only posts by specific authors"
+		}
 	]
 }


### PR DESCRIPTION
This is a quick hacky implementation I put together for supporting filtering by authors in Mastodon's connector. I know there's no chance for this to get merged in its current form but I am opening this PR as a place to discuss how a more proper implementation for this could look like in the future

## Why?
Tapestry's support for timelines instantly inspired me to figure out if I can make a timeline with only specific people from Mastodon, for example if you want to create a timeline of people who do art, or people who talk about a specific subject.

## The implementation
Current implementation is pretty terrible! You have to specify each person you're interested in manually in a long string. Support for multi-selects in the `ui-config` is not present right now and populating the configuration programmatically is also missing. If there was native support for lists of strings that would already be a major improvement.

## Good news
It works! This achieves what I want and is fairly minor edit that I can personally easily rebase when changes occur in upstream's Mastodon connector. I intend to use it and keep maintaining it for my personal use.


I am curious if others are interested in something like this too and if Iconfactory thinks this is worth pursuing. Feel free to close this PR as won't-do if you're not interested in pursuing something like this upstream.

Either ways, the app is excellent and I am loving using it, thank you this gem ❤️ 