### PR TITLE
Bluesky: add Graysky as openable app

### DIFF
--- a/Plugins/social.bsky/apps.json
+++ b/Plugins/social.bsky/apps.json
@@ -5,6 +5,12 @@
 			"name": "Bluesky",
 			"template": "bluesky:__PATH__",
 			"pattern": "https://bsky.app"
+		},
+		{
+			"id": "dev.mozzius.graysky",
+			"name": "Graysky",
+			"template": "graysky:/__PATH__",
+			"pattern": "https://bsky.app"
 		}
 	]
 }


### PR DESCRIPTION
URL scheme tested as custom and follows from:


https://github.com/mozzius/graysky/blob/2bd301a726d84f00ec2d7b470364c817b7823a27/apps/expo/OpenInGrayskyExtension/src/content.js#L16

while I was in there, I tried to no avail to figure out and also add:
- https://www.skeetsapp.com/ (opens broadly on `skeets://` , but didn’t like any path I gave it from there and doesn’t seem documented)
- https://openvibe.social/ — could not find a scheme at all (haven’t peaked at ipa’s plist tho), if there is one could maybe apply to mastodon (and if they ever get plugins: nostr, and threads (if that doesn’t talk ActivityPub consistently enough to play masto)