### PR TITLE
Override the crosstalk mode for GoComics

### DIFF
--- a/Plugins/com.gocomics/plugin-config.json
+++ b/Plugins/com.gocomics/plugin-config.json
@@ -7,5 +7,6 @@
 	"verify_variables": true,
 	"provides_attachments": true,
 	"check_interval": 300,
-	"version": 1
+	"crosstalk": "exclusive",
+	"version": 2
 }


### PR DESCRIPTION
I added a way for connectors to override the crosstalk mode and applied this to GoComics to prevent it from crosstalking with its own feeds. (FoxTrot and FoxTrot Classic are especially problematic for crosstalk which can't tell them apart.)